### PR TITLE
Fixing compilation error

### DIFF
--- a/ios-client-side/CMDownloadTracker.m
+++ b/ios-client-side/CMDownloadTracker.m
@@ -58,7 +58,7 @@
         else
         {
             // Alloc memory based on above call
-            if((msgBuffer = malloc(length)) == NULL)
+            if((msgBuffer = (char *)malloc(length)) == NULL)
                 errorFlag = @"buffer allocation failure";
             else
             {


### PR DESCRIPTION
Fixing compilation error “CMDownloadTracker.m:61:27: Assigning to 'char
*' from incompatible type 'void *'”